### PR TITLE
use state to get bgp status and the number of accepted routes

### DIFF
--- a/bgperf.py
+++ b/bgperf.py
@@ -201,7 +201,7 @@ def bench(args):
         if info['who'] == m.name:
             now = datetime.datetime.now()
             elapsed = now - start
-            recved = info['info']['accepted'] if 'accepted' in info['info'] else 0
+            recved = info['state']['adj-table']['accepted'] if 'accepted' in info['state']['adj-table'] else 0
             if elapsed.seconds > 0:
                 rm_line()
             print 'elapsed: {0}sec, cpu: {1:>4.2f}%, mem: {2}, recved: {3}'.format(elapsed.seconds, cpu, mem_human(mem), recved)

--- a/monitor.py
+++ b/monitor.py
@@ -62,7 +62,7 @@ gobgpd -t yaml -f {1}/{2} -l {3} > {1}/gobgpd.log 2>&1
     def wait_established(self, neighbor):
         while True:
             neigh = json.loads(self.local('gobgp neighbor {0} -j'.format(neighbor)))
-            if neigh['info']['bgp_state'] == 'BGP_FSM_ESTABLISHED':
+            if neigh['state']['session-state'] == 'established':
                 return
             time.sleep(1)
 
@@ -72,7 +72,8 @@ gobgpd -t yaml -f {1}/{2} -l {3} > {1}/gobgpd.log 2>&1
             while True:
                 info = json.loads(self.local('gobgp neighbor -j'))[0]
                 info['who'] = self.name
-                if 'info' in info and 'accepted' in info['info'] and len(cps) > 0 and int(cps[0]) == int(info['info']['accepted']):
+                state = info['state']
+                if 'adj-table' in state and 'accepted' in state['adj-table'] and len(cps) > 0 and int(cps[0]) == int(state['adj-table']['accepted']):
                     cps.pop(0)
                     info['checked'] = True
                 else:


### PR DESCRIPTION
bgperf cannot get a peer status and the number of accepted routes.
This is because the latest GoBGP locates them under "state" object in json that "gobgp neighbor -j" command returns. This patch enables bgperf to get them from the "state" object.