### PR TITLE
Fix BIRD config generation

### DIFF
--- a/bird.py
+++ b/bird.py
@@ -152,7 +152,7 @@ return true;
                         match_info.append((match['type'], n))
                     f.write(gen_filter(k, match_info))
 
-            for n in sorted(conf['tester'].values() + [conf['monitor']], key=lambda n: n['as']):
+            for n in sorted(list(flatten(t.get('tester', {}).values() for t in conf['testers'])) + [conf['monitor']], key=lambda n: n['as']):
                 f.write(gen_neighbor_config(n))
             f.flush()
         self.config_name = name


### PR DESCRIPTION
Before of this:

```
$ ./bgperf.py bench -t bird
run bird
remove container: bird
Traceback (most recent call last):
  File "./bgperf.py", line 406, in <module>
    args.func(args)
  File "./bgperf.py", line 178, in bench
    target.run(conf, brname)
  File "/home/pierky/bgperf/bird.py", line 165, in run
    self.write_config(conf)
  File "/home/pierky/bgperf/bird.py", line 155, in write_config
    for n in sorted(conf['tester'].values() + [conf['monitor']], key=lambda n: n['as']):
KeyError: 'tester'
```