### PR TITLE
fix a bug of pid index

### DIFF
--- a/base.py
+++ b/base.py
@@ -260,7 +260,7 @@ class Tester(Container):
         prev_pid = 0
         for lines in output:
             for line in lines.strip().split('\n'):
-                pid = int(line.split('|')[2])
+                pid = int(line.split('|')[1])
                 if pid != prev_pid:
                     prev_pid = pid
                     cnt += 1


### PR DESCRIPTION
Using the latest ubuntu image, the index of PID is '1' not '2'.