### PR TITLE
Update GoBGP requirements

### DIFF
--- a/gobgp.py
+++ b/gobgp.py
@@ -26,11 +26,12 @@ class GoBGP(Container):
     @classmethod
     def build_image(cls, force=False, tag='bgperf/gobgp', checkout='HEAD', nocache=False):
         cls.dockerfile = '''
-FROM golang:1.6
+FROM golang:1.8
 WORKDIR /root
+RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -v github.com/osrg/gobgp/gobgpd
 RUN go get -v github.com/osrg/gobgp/gobgp
-RUN cd $GOPATH/src/github.com/osrg/gobgp && git checkout {0}
+RUN cd $GOPATH/src/github.com/osrg/gobgp && git checkout {0} && dep ensure
 RUN go install github.com/osrg/gobgp/gobgpd
 RUN go install github.com/osrg/gobgp/gobgp
 '''.format(checkout)


### PR DESCRIPTION
This changes make the build recipe for GoBGP become up-to-date and unbreak preparing new docker images or updating old ones.

The new instructions were gathered from upstream:
https://github.com/osrg/gobgp/commit/c0316cbc20054c4ee9dee34fa6301c4c60d6c9b5#diff-04c6e90faac2675aa89e2176d2eec7d8
and
https://github.com/osrg/gobgp/commit/aa2b1c2405b9f996d8bab02d95fd0f696ddbf953#diff-04c6e90faac2675aa89e2176d2eec7d8